### PR TITLE
Prevent Connection.open() from hanging when handshake never succeeds

### DIFF
--- a/asyncpusher/connection.py
+++ b/asyncpusher/connection.py
@@ -48,6 +48,11 @@ class Connection:
         self._activity_timeout = 120
         self._pong_timeout = 30
         self.state = self.State.IDLE
+        # Signals open() once the connection outcome is known: successful
+        # handshake, fatal failure, or _run_forever exiting without ever
+        # connecting. Prevents open() from hanging forever in those last
+        # two cases.
+        self._opened = asyncio.Event()
 
         self.bind("pusher:connection_established", self._handle_connection)
         self.bind("pusher:connection_failed", self._handle_failure)
@@ -56,8 +61,11 @@ class Connection:
     async def open(self):
         self._loop.create_task(self._run_forever())
 
-        while self.state != self.State.CONNECTED:
-            await asyncio.sleep(1)
+        await self._opened.wait()
+
+        if self.state != self.State.CONNECTED:
+            msg = f"Pusher connection could not be established (state={self.state.name})"
+            raise ConnectionError(msg)
 
     async def close(self):
         self._stop = True
@@ -66,14 +74,19 @@ class Connection:
                 await self._ws.close()
 
     async def _run_forever(self):
-        while not self._stop:
-            async with aiohttp.ClientSession() as session:
-                try:
-                    await self._connect(session)
-                except aiohttp.ClientError:
-                    self._log.exception("Exception while connecting to web socket")
-                    self._connection_attempts += 1
-        self._log.info("End of forever")
+        try:
+            while not self._stop:
+                async with aiohttp.ClientSession() as session:
+                    try:
+                        await self._connect(session)
+                    except aiohttp.ClientError:
+                        self._log.exception("Exception while connecting to web socket")
+                        self._connection_attempts += 1
+            self._log.info("End of forever")
+        finally:
+            # Guarantee open() wakes up even if we exit before CONNECTED
+            # (fatal close code, unhandled exception, cancellation).
+            self._opened.set()
 
     async def _connect(self, session: aiohttp.ClientSession):
         self._log.info("Pusher connecting...")
@@ -162,10 +175,12 @@ class Connection:
         if self._ws is not None:
             self._ws._heartbeat = self._activity_timeout
         self.state = self.State.CONNECTED
+        self._opened.set()
         self._log.info(f"Connection established: {data}")
 
     async def _handle_failure(self, data):
         self.state = self.State.FAILED
+        self._opened.set()
         self._log.error(f"Connection failed: {data}")
 
     async def _handle_error(self, data):

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,0 +1,76 @@
+import asyncio
+import logging
+import unittest
+
+from asyncpusher.connection import Connection
+
+
+async def _noop_callback(channel, event, data):
+    pass
+
+
+def _make_connection():
+    loop = asyncio.get_event_loop()
+    log = logging.getLogger("asyncpusher.test")
+    return Connection(loop, "ws://127.0.0.1:1/fake", _noop_callback, log)
+
+
+class ConnectionOpenTest(unittest.IsolatedAsyncioTestCase):
+    """
+    Regression tests for the `open()` hang bug: if _run_forever ever exits
+    without the server sending pusher:connection_established, open() used to
+    poll state == CONNECTED forever. It now waits on an Event that is
+    guaranteed to be set, and raises ConnectionError if state never reaches
+    CONNECTED.
+    """
+
+    async def test_open_returns_when_connection_established(self):
+        conn = _make_connection()
+
+        async def fake_connect(_session):
+            await conn._handle_connection({"socket_id": "1.2", "activity_timeout": 120})
+            conn._stop = True
+
+        conn._connect = fake_connect
+
+        await asyncio.wait_for(conn.open(), timeout=2.0)
+        self.assertEqual(conn.state, Connection.State.CONNECTED)
+
+    async def test_open_raises_when_stop_is_set_without_connecting(self):
+        conn = _make_connection()
+
+        async def fake_connect(_session):
+            conn._stop = True
+
+        conn._connect = fake_connect
+
+        with self.assertRaises(ConnectionError):
+            await asyncio.wait_for(conn.open(), timeout=2.0)
+
+    async def test_open_raises_on_pusher_connection_failed(self):
+        conn = _make_connection()
+
+        async def fake_connect(_session):
+            await conn._handle_failure({"code": 4001, "message": "bad app key"})
+            conn._stop = True
+
+        conn._connect = fake_connect
+
+        with self.assertRaises(ConnectionError):
+            await asyncio.wait_for(conn.open(), timeout=2.0)
+        self.assertEqual(conn.state, Connection.State.FAILED)
+
+    async def test_open_raises_when_run_forever_crashes(self):
+        conn = _make_connection()
+
+        async def fake_connect(_session):
+            raise RuntimeError("boom")
+
+        conn._connect = fake_connect
+
+        with self.assertRaises(ConnectionError):
+            await asyncio.wait_for(conn.open(), timeout=2.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

`Connection.open()` currently polls `state == CONNECTED` in a `while True: await asyncio.sleep(1)` loop. If the initial connection never reaches `CONNECTED`, `open()` hangs forever. Concrete cases that trigger this today:

1. Server closes with a 4000-4099 code (e.g. bad app key, protocol mismatch). `_dispatch` sets `_stop = True`, `_run_forever` exits, but `state` never becomes `CONNECTED` — `open()` loops forever.
2. Server sends `pusher:connection_failed`. `_handle_failure` sets `state = FAILED` — `open()` still loops forever.
3. `_connect` raises anything other than `aiohttp.ClientError` (unexpected `OSError`, `RuntimeError`, `TimeoutError` not wrapped by aiohttp, etc). `_run_forever` dies, state never changes, `open()` hangs.

In all three cases the caller gets a task that never returns and no indication anything is wrong.

## Fix

- Add `self._opened = asyncio.Event()` on `Connection`.
- `open()` awaits the event instead of polling, then raises `ConnectionError` if the resulting state is not `CONNECTED`.
- The event is set from three places:
  - `_handle_connection` (success)
  - `_handle_failure` (server-side `pusher:connection_failed`)
  - `_run_forever`'s `finally` block — covers `_stop=True`, unhandled exceptions, and cancellation.

Reconnect logic is unchanged: `_run_forever` still loops on transient closes. Subsequent `_handle_connection` calls call `.set()` on an already-set event (no-op), so nothing breaks.

## Tests

Added `tests/test_connection.py` with four regression cases that exercise `open()` without a real Pusher server (the existing `test_pusher.py` requires `PUSHER_APP_KEY` and a local auth endpoint):

- `test_open_returns_when_connection_established`
- `test_open_raises_when_stop_is_set_without_connecting`
- `test_open_raises_on_pusher_connection_failed`
- `test_open_raises_when_run_forever_crashes`

All four pass. Ran `black --check` and `ruff check` against the modified files — clean.