### PR TITLE
Raise ConnectionError from send_event instead of silently dropping

### DIFF
--- a/asyncpusher/connection.py
+++ b/asyncpusher/connection.py
@@ -151,9 +151,13 @@ class Connection:
         while retry_count > 0 and self.state != self.State.CONNECTED:
             await asyncio.sleep(1)
             retry_count -= 1
-        if self.state == self.State.CONNECTED:
-            if self._ws is not None and not self._ws.closed:
-                await self._ws.send_json(event)
+        if self.state != self.State.CONNECTED:
+            msg = f"Cannot send event: connection not established (state={self.state.name})"
+            raise ConnectionError(msg)
+        if self._ws is None or self._ws.closed:
+            msg = "Cannot send event: websocket is not open"
+            raise ConnectionError(msg)
+        await self._ws.send_json(event)
 
     async def _handle_connection(self, data):
         self.socket_id = data["socket_id"]

--- a/tests/test_send_event.py
+++ b/tests/test_send_event.py
@@ -1,0 +1,77 @@
+import asyncio
+import logging
+import unittest
+from unittest.mock import patch
+
+from asyncpusher.connection import Connection
+
+
+async def _noop_callback(channel, event, data):
+    pass
+
+
+def _make_connection():
+    loop = asyncio.get_event_loop()
+    log = logging.getLogger("asyncpusher.test")
+    return Connection(loop, "ws://127.0.0.1:1/fake", _noop_callback, log)
+
+
+class FakeWebSocket:
+    def __init__(self, *, closed: bool = False):
+        self.closed = closed
+        self.sent: list = []
+
+    async def send_json(self, event):
+        self.sent.append(event)
+
+
+async def _noop_sleep(_delay):
+    # Avoid waiting through the retry loop during tests
+    return
+
+
+class SendEventTest(unittest.IsolatedAsyncioTestCase):
+    """
+    send_event used to silently drop events when the connection was not ready
+    or the websocket was closed. It now raises ConnectionError so callers
+    (e.g. auto-resubscribe after reconnect) can detect and log failures.
+    """
+
+    async def test_sends_when_connected(self):
+        conn = _make_connection()
+        ws = FakeWebSocket()
+        conn._ws = ws
+        conn.state = Connection.State.CONNECTED
+
+        payload = {"event": "pusher:subscribe", "data": {"channel": "foo"}}
+        await conn.send_event(payload)
+
+        self.assertEqual(ws.sent, [payload])
+
+    async def test_raises_when_state_never_reaches_connected(self):
+        conn = _make_connection()
+        conn.state = Connection.State.FAILED
+
+        with patch("asyncpusher.connection.asyncio.sleep", new=_noop_sleep):
+            with self.assertRaises(ConnectionError):
+                await conn.send_event({"event": "test"})
+
+    async def test_raises_when_websocket_is_none(self):
+        conn = _make_connection()
+        conn.state = Connection.State.CONNECTED
+        conn._ws = None
+
+        with self.assertRaises(ConnectionError):
+            await conn.send_event({"event": "test"})
+
+    async def test_raises_when_websocket_closed(self):
+        conn = _make_connection()
+        conn._ws = FakeWebSocket(closed=True)
+        conn.state = Connection.State.CONNECTED
+
+        with self.assertRaises(ConnectionError):
+            await conn.send_event({"event": "test"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

`Connection.send_event` currently swallows two failure modes without any signal to the caller:

```python
async def send_event(self, event):
    retry_count = 5
    while retry_count > 0 and self.state != self.State.CONNECTED:
        await asyncio.sleep(1)
        retry_count -= 1
    if self.state == self.State.CONNECTED:
        if self._ws is not None and not self._ws.closed:
            await self._ws.send_json(event)
```

If the connection never reaches `CONNECTED` after 5 s, or if `_ws` is `None`/closed at send time, the method returns normally and the event is dropped. There is no exception, no log line, and no return value to inspect.

This is most visible with `auto_sub=True`: after a reconnect, `_resubscribe` calls `_subscribe → send_event`. If the websocket is briefly down again at that point, the subscribe frame is silently lost — the channel stays unsubscribed but `pusher.channels` still holds the `Channel` object in a stale `UNSUBSCRIBED` state, and events for that channel never arrive.

## Fix

Replace the silent fallthrough with explicit `ConnectionError`s. Callers that previously "succeeded" now see the failure and can log or retry. `_handle_event` in `Connection` already wraps callback dispatch in `try/except Exception`, so `_resubscribe` failures get logged instead of raising out of the event loop.

## Tests

Added `tests/test_send_event.py` with four cases that exercise `send_event` without a real Pusher server:

- `test_sends_when_connected` — happy path writes to the mocked websocket.
- `test_raises_when_state_never_reaches_connected`
- `test_raises_when_websocket_is_none`
- `test_raises_when_websocket_closed`

`asyncio.sleep` is patched in the first raising case so the 5-iteration retry runs instantly.

All four pass; `black --check` and `ruff check` are clean on the modified files.

## Notes

- Independent of #2 (the `open()` hang fix); this PR branches from `main`.
- Minimal diff, no new parameters, no changes to the retry duration. A follow-up could make `max_wait_seconds` configurable.