### PR TITLE
Make reconnect loop survive unexpected errors and reset backoff on success

### DIFF
--- a/asyncpusher/connection.py
+++ b/asyncpusher/connection.py
@@ -70,7 +70,12 @@ class Connection:
             async with aiohttp.ClientSession() as session:
                 try:
                     await self._connect(session)
-                except aiohttp.ClientError:
+                except Exception:
+                    # Catch everything except BaseException subclasses (notably
+                    # CancelledError). Anything narrower leaks non-ClientError
+                    # failures (asyncio.TimeoutError, OSError from aiodns,
+                    # malformed JSON, bugs in internal handlers, etc.) and kills
+                    # _run_forever silently, permanently disabling reconnect.
                     self._log.exception("Exception while connecting to web socket")
                     self._connection_attempts += 1
         self._log.info("End of forever")
@@ -162,6 +167,9 @@ class Connection:
         if self._ws is not None:
             self._ws._heartbeat = self._activity_timeout
         self.state = self.State.CONNECTED
+        # Reset so a future disconnect-then-reconnect starts its backoff from
+        # scratch instead of inheriting the pre-success attempt count.
+        self._connection_attempts = 0
         self._log.info(f"Connection established: {data}")
 
     async def _handle_failure(self, data):

--- a/tests/test_reconnect_robustness.py
+++ b/tests/test_reconnect_robustness.py
@@ -1,0 +1,79 @@
+import asyncio
+import logging
+import unittest
+
+from asyncpusher.connection import Connection
+
+
+async def _noop_callback(channel, event, data):
+    pass
+
+
+def _make_connection():
+    loop = asyncio.get_event_loop()
+    log = logging.getLogger("asyncpusher.test")
+    return Connection(loop, "ws://127.0.0.1:1/fake", _noop_callback, log)
+
+
+class RunForeverTest(unittest.IsolatedAsyncioTestCase):
+    """
+    _run_forever used to only catch aiohttp.ClientError, so any other
+    exception (asyncio.TimeoutError, OSError from DNS, JSONDecodeError,
+    internal-handler KeyError, ...) killed the reconnect loop silently.
+    """
+
+    async def test_continues_after_non_client_error(self):
+        conn = _make_connection()
+        call_count = 0
+
+        async def fake_connect(_session):
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                raise RuntimeError("boom")
+            conn._stop = True
+
+        conn._connect = fake_connect
+
+        await asyncio.wait_for(conn._run_forever(), timeout=2.0)
+
+        self.assertEqual(call_count, 3)
+        self.assertEqual(conn._connection_attempts, 2)
+
+    async def test_cancelled_error_is_not_swallowed(self):
+        conn = _make_connection()
+
+        async def fake_connect(_session):
+            await asyncio.sleep(10)
+
+        conn._connect = fake_connect
+
+        task = asyncio.create_task(conn._run_forever())
+        # yield so the task enters the fake_connect sleep
+        await asyncio.sleep(0.05)
+        task.cancel()
+
+        with self.assertRaises(asyncio.CancelledError):
+            await task
+
+
+class HandleConnectionResetTest(unittest.IsolatedAsyncioTestCase):
+    """
+    _handle_connection did not reset _connection_attempts, so backoff
+    accumulated across the full lifetime of the client: connecting after
+    5 failed attempts and then getting disconnected would start the next
+    reconnect from attempt #6, waiting tens of seconds unnecessarily.
+    """
+
+    async def test_resets_connection_attempts_on_success(self):
+        conn = _make_connection()
+        conn._connection_attempts = 7
+
+        await conn._handle_connection({"socket_id": "42.1", "activity_timeout": 120})
+
+        self.assertEqual(conn._connection_attempts, 0)
+        self.assertEqual(conn.state, Connection.State.CONNECTED)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Two small, related improvements to `Connection`'s reconnect loop. Both touch only a few lines and are independent of #2/#3, so they're bundled here.

## 1. `_run_forever` catches non-`ClientError` exceptions

The loop is named `_run_forever` but currently only catches `aiohttp.ClientError`. Anything else — `asyncio.TimeoutError` (not always wrapped by aiohttp in 3.11+), `OSError` from `aiodns`, `json.JSONDecodeError` from malformed server messages in `_dispatch`, or a `KeyError` in an internal handler like `_handle_connection` on a bad payload — propagates out and kills the task. The client then sits in `CLOSED` forever with no reconnect and no user-visible signal beyond `loop.default_exception_handler` (usually stderr).

Widened to `except Exception`. `asyncio.CancelledError` is a `BaseException` since Python 3.8, so normal task cancellation / shutdown still works as before.

## 2. Reset `_connection_attempts` on successful handshake

`_connection_attempts` is only decremented (sort of — set to 0) on certain close codes in `_dispatch`, and incremented on failures. It is **not** reset when a connection actually succeeds. So a client that takes 5 attempts to connect the first time, then later gets disconnected, starts its next reconnect from attempt #6 — `_get_wait_time` can give tens of seconds of backoff for what should be a fresh reconnect.

Added `self._connection_attempts = 0` in `_handle_connection` (right after the state transitions to `CONNECTED`).

## Tests

`tests/test_reconnect_robustness.py`, three cases:

- `test_continues_after_non_client_error` — `_connect` raises `RuntimeError` twice, loop keeps going, attempts count goes to 2.
- `test_cancelled_error_is_not_swallowed` — cancelling the `_run_forever` task surfaces `CancelledError` to the awaiter.
- `test_resets_connection_attempts_on_success` — preseeded attempts = 7, after `_handle_connection` it's 0.

`black --check` and `ruff check` are clean on the modified files.